### PR TITLE
feat(accounts): add account list on sidebar

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "validate": "yarn lint:fix && yarn format"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -22,7 +22,8 @@
   "auth.signIn.login.label": "Login",
   "auth.signIn.password.label": "Password",
   "auth.signIn.submit": "Sign in",
-  "accounts.list": "Accounts",
+  "accounts.list.checking": "Checking",
+  "accounts.list.savings": "Savings",
   "accounts.netWorth": "Net Worth",
   "accounts.add": "Add Account",
   "accounts.add.name": "Name",
@@ -31,5 +32,6 @@
   "accounts.add.type.Checking": "Checking",
   "accounts.add.type.Savings": "Savings",
   "actions.cancel": "Cancel",
-  "actions.save": "Save"
+  "actions.save": "Save",
+  "common.noData": "No data"
 }

--- a/src/app/main/MainLayout.tsx
+++ b/src/app/main/MainLayout.tsx
@@ -15,9 +15,12 @@ import {
   SidebarTrigger,
 } from '@/components/ui/Sidebar'
 import { AccountsSidebarContent } from '@/features/accounts/components/AccountsSidebarContent'
+import { useSearchParams } from '@/hooks/useSearchParams'
 
 function MainLayout() {
   const { t } = useTranslation()
+  const [selectedAccountId, setSelectedAccountId] = useSearchParams<string | null>('accountId')
+
   return (
     <SidebarProvider
       style={
@@ -41,7 +44,7 @@ function MainLayout() {
           </SidebarMenu>
         </SidebarHeader>
 
-        <AccountsSidebarContent />
+        <AccountsSidebarContent selectedAccountId={selectedAccountId} onAccountClick={setSelectedAccountId} />
       </Sidebar>
 
       <SidebarInset>

--- a/src/features/accounts/components/AccountsList.tsx
+++ b/src/features/accounts/components/AccountsList.tsx
@@ -1,17 +1,85 @@
+import { useQuery } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
 
-import { SidebarGroup, SidebarGroupContent, SidebarGroupLabel, SidebarMenu, SidebarMenuItem } from '@/components/ui/Sidebar'
+import { AccountsQueryOptions } from '@/api/endpoints/AccountsEndpoints'
+import {
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from '@/components/ui/Sidebar'
+import { cn, cnCurrencyColor, formatCurrency } from '@/lib/utils'
+import type { GetAccountsResponseDto } from '@/types/accounts/responses/GetAccountsResponseDto'
 
-function AccountsList() {
+type AccountsListProps = {
+  selectedAccountId: string | null
+  onAccountClick: (accountId: string | null) => void
+}
+
+function AccountsList({ selectedAccountId, onAccountClick }: AccountsListProps) {
   const { t } = useTranslation()
+
+  const { data: accounts } = useQuery(AccountsQueryOptions.getAccounts())
+
+  const checkingAccounts = accounts?.filter((account) => account.type === 'Checking') ?? []
+  const savingsAccounts = accounts?.filter((account) => account.type === 'Savings') ?? []
+
   return (
-    <SidebarGroup>
-      <SidebarGroupLabel>{t('accounts.list')}</SidebarGroupLabel>
+    <>
+      <AccountGroup
+        accounts={checkingAccounts}
+        label={t('accounts.list.checking')}
+        labelNoData={t('common.noData')}
+        selectedAccountId={selectedAccountId}
+        onAccountClick={onAccountClick}
+      />
+      <AccountGroup
+        accounts={savingsAccounts}
+        label={t('accounts.list.savings')}
+        labelNoData={t('common.noData')}
+        selectedAccountId={selectedAccountId}
+        onAccountClick={onAccountClick}
+      />
+    </>
+  )
+}
+
+type AccountGroupProps = {
+  accounts: GetAccountsResponseDto[]
+  label: string
+  labelNoData: string
+  selectedAccountId: string | null
+  onAccountClick: (accountId: string | null) => void
+}
+
+function AccountGroup({ accounts, label, labelNoData, selectedAccountId, onAccountClick }: AccountGroupProps) {
+  return (
+    <SidebarGroup className="py-0">
+      <SidebarGroupLabel>{label}</SidebarGroupLabel>
       <SidebarGroupContent className="flex flex-col gap-2">
         <SidebarMenu>
-          <SidebarMenuItem>
-            <span>Temp</span>
-          </SidebarMenuItem>
+          {accounts.length === 0 ? (
+            <SidebarMenuItem>
+              <SidebarMenuButton disabled>{labelNoData}</SidebarMenuButton>
+            </SidebarMenuItem>
+          ) : (
+            accounts.map((account) => (
+              <SidebarMenuItem key={account.id}>
+                <SidebarMenuButton
+                  className="pl-4"
+                  isActive={selectedAccountId === account.id}
+                  onClick={() => onAccountClick(account.id)}
+                >
+                  <span>{account.name}</span>
+                  <span className={cn(cnCurrencyColor(account.balance), 'ms-auto font-semibold')}>
+                    {formatCurrency(account.balance)}
+                  </span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            ))
+          )}
         </SidebarMenu>
       </SidebarGroupContent>
     </SidebarGroup>

--- a/src/features/accounts/components/AccountsNetWorth.tsx
+++ b/src/features/accounts/components/AccountsNetWorth.tsx
@@ -6,7 +6,12 @@ import { AccountsQueryOptions } from '@/api/endpoints/AccountsEndpoints'
 import { SidebarGroup, SidebarGroupContent, SidebarMenu, SidebarMenuButton } from '@/components/ui/Sidebar'
 import { cn, cnCurrencyColor, formatCurrency } from '@/lib/utils'
 
-function AccountsNetWorth() {
+type AccountsNetWorthProps = {
+  selectedAccountId: string | null
+  onAccountClick: (accountId: string | null) => void
+}
+
+function AccountsNetWorth({ selectedAccountId, onAccountClick }: AccountsNetWorthProps) {
   const { t } = useTranslation()
 
   const { data: accounts } = useQuery(AccountsQueryOptions.getAccounts())
@@ -17,7 +22,12 @@ function AccountsNetWorth() {
     <SidebarGroup>
       <SidebarGroupContent>
         <SidebarMenu>
-          <SidebarMenuButton className="border" size="lg">
+          <SidebarMenuButton
+            className="border"
+            isActive={selectedAccountId === null}
+            size="lg"
+            onClick={() => onAccountClick(null)}
+          >
             <ChartPieIcon />
             <span>{t('accounts.netWorth')}</span>
             <span className={cn(cnCurrencyColor(netWorth), 'ms-auto font-semibold')}>{formatCurrency(netWorth)}</span>

--- a/src/features/accounts/components/AccountsSidebarContent.tsx
+++ b/src/features/accounts/components/AccountsSidebarContent.tsx
@@ -5,12 +5,16 @@ import { AccountsAddFormDialog } from './AccountsAddFormDialog'
 import { AccountsList } from './AccountsList'
 import { AccountsNetWorth } from './AccountsNetWorth'
 
-function AccountsSidebarContent() {
+type AccountsSidebarContentProps = {
+  selectedAccountId: string | null
+  onAccountClick: (accountId: string | null) => void
+}
+
+function AccountsSidebarContent({ selectedAccountId, onAccountClick }: AccountsSidebarContentProps) {
   return (
     <SidebarContent>
-      <AccountsNetWorth />
-
-      <AccountsList />
+      <AccountsNetWorth selectedAccountId={selectedAccountId} onAccountClick={onAccountClick} />
+      <AccountsList selectedAccountId={selectedAccountId} onAccountClick={onAccountClick} />
 
       <AccountsAddButton />
       <AccountsAddFormDialog />

--- a/src/hooks/useSearchParams.ts
+++ b/src/hooks/useSearchParams.ts
@@ -1,0 +1,25 @@
+import { useCallback } from 'react'
+import { useSearchParams as useSearchParamsRouter } from 'react-router-dom'
+
+type TUseSearchParams = string | null
+
+export function useSearchParams<T extends TUseSearchParams>(queryParam: string) {
+  const [searchParams, setSearchParams] = useSearchParamsRouter()
+  const value = searchParams.get(queryParam)
+
+  const setValue = useCallback(
+    (value: T) => {
+      setSearchParams((prev) => {
+        if (value == null) {
+          prev.delete(queryParam)
+        } else {
+          prev.set(queryParam, value.toString())
+        }
+        return prev
+      })
+    },
+    [setSearchParams, queryParam]
+  )
+
+  return [value, setValue] as const
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -69,7 +69,7 @@ export function formatCurrency(amount: number, currency = 'EUR', locale = 'fr-FR
   return new Intl.NumberFormat(locale, {
     style: 'currency',
     currency,
-    minimumFractionDigits: 0,
+    minimumFractionDigits: 2,
     maximumFractionDigits: 2,
     currencyDisplay: 'symbol',
   }).format(amount)


### PR DESCRIPTION
**Sidebar account selection and state management:**

* Added a custom `useSearchParams` hook to synchronize the selected account with the URL's `accountId` search parameter, enabling deep linking and browser navigation support (`src/hooks/useSearchParams.ts`, `src/app/main/MainLayout.tsx`) [[1]](diffhunk://#diff-858aab1fb942ded5bbf3acc8cf8bf33665bd310788247e0d27bbbb4720f30cdeR1-R21) [[2]](diffhunk://#diff-6369df88e9c7c96272f380ef5586c9ae3959c313124eda503a020ae451814c74R18-R23) [[3]](diffhunk://#diff-6369df88e9c7c96272f380ef5586c9ae3959c313124eda503a020ae451814c74L44-R47).
* Updated `AccountsSidebarContent`, `AccountsList`, and `AccountsNetWorth` components to accept and propagate `selectedAccountId` and `onAccountClick` props, ensuring consistent account selection state across the sidebar (`src/features/accounts/components/AccountsSidebarContent.tsx`, `src/features/accounts/components/AccountsList.tsx`, `src/features/accounts/components/AccountsNetWorth.tsx`) [[1]](diffhunk://#diff-a03fa85850c3bac60b44c92ced03dfd3112dc3249e4c25059f1c8db6be88e556L8-R17) [[2]](diffhunk://#diff-6ad1808fdc8c5a0b16e8d76a46cf9e022fa0d64dc403e52971a4b3af0568c8d5R1-R77) [[3]](diffhunk://#diff-9f10652ccbf8eabcb4e22f7aadf3cf24ca0f5da0e632328c8ed7806306440a3aL9-R14) [[4]](diffhunk://#diff-9f10652ccbf8eabcb4e22f7aadf3cf24ca0f5da0e632328c8ed7806306440a3aL20-R30).

**UI/UX improvements for accounts sidebar:**

* Split the accounts list into "Checking" and "Savings" groups, each with its own label and content, and display a disabled "No data" button when there are no accounts in a group (`src/features/accounts/components/AccountsList.tsx`, `public/locales/en.json`) [[1]](diffhunk://#diff-6ad1808fdc8c5a0b16e8d76a46cf9e022fa0d64dc403e52971a4b3af0568c8d5R1-R77) [[2]](diffhunk://#diff-1ef07a459de08da33c9f950f32e4e739683a016d219c16503bf8c3a5e2c973c7L25-R26) [[3]](diffhunk://#diff-1ef07a459de08da33c9f950f32e4e739683a016d219c16503bf8c3a5e2c973c7L34-R36).
* Highlight the currently selected account and allow users to select the "Net Worth" overview, which sets `selectedAccountId` to `null` (`src/features/accounts/components/AccountsNetWorth.tsx`).

**Localization and formatting enhancements:**

* Updated English locale strings to support new sidebar labels and "No data" messaging (`public/locales/en.json`) [[1]](diffhunk://#diff-1ef07a459de08da33c9f950f32e4e739683a016d219c16503bf8c3a5e2c973c7L25-R26) [[2]](diffhunk://#diff-1ef07a459de08da33c9f950f32e4e739683a016d219c16503bf8c3a5e2c973c7L34-R36).
* Changed the default currency formatting to always show two decimal places for consistency (`src/lib/utils.ts`).