### PR TITLE
feat(accounts): add account bank name

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -1,6 +1,8 @@
 {
   "errors.Account.Name.Required": "Name required",
   "errors.Account.Name.TooLong": "Name too long",
+  "errors.Account.Bank.Required": "Bank required",
+  "errors.Account.Bank.TooLong": "Bank too long",
   "errors.Account.AccountType.Unknown": "Invalid account type",
   "errors.Account.NotFound": "Account not found",
   "errors.Account.AlreadyDeleted": "Already deleted",
@@ -27,6 +29,7 @@
   "accounts.netWorth": "Net Worth",
   "accounts.add": "Add Account",
   "accounts.add.name": "Name",
+  "accounts.add.bank": "Bank",
   "accounts.add.initialBalance": "Initial Balance",
   "accounts.add.type": "Type",
   "accounts.add.type.Checking": "Checking",

--- a/src/features/accounts/components/AccountsAddFormDialog.tsx
+++ b/src/features/accounts/components/AccountsAddFormDialog.tsx
@@ -50,6 +50,7 @@ function AccountAddForm({ className }: React.ComponentProps<'form'>) {
     resolver: zodResolver(CreateAccountFormSchema),
     defaultValues: {
       name: '',
+      bank: '',
       type: 'Checking',
       initialBalance: 0,
     },
@@ -70,6 +71,7 @@ function AccountAddForm({ className }: React.ComponentProps<'form'>) {
     <form className={cn('grid items-start gap-6', className)} onSubmit={form.handleSubmit(onSubmit)}>
       <FieldGroup>
         <InputControlled autoFocus control={form.control} disabled={isPending} label={t('accounts.add.name')} name="name" />
+        <InputControlled control={form.control} disabled={isPending} label={t('accounts.add.bank')} name="bank" />
         <div className="grid grid-cols-2 gap-2">
           <SelectControlled
             control={form.control}

--- a/src/features/accounts/components/AccountsList.tsx
+++ b/src/features/accounts/components/AccountsList.tsx
@@ -70,9 +70,13 @@ function AccountGroup({ accounts, label, labelNoData, selectedAccountId, onAccou
                 <SidebarMenuButton
                   className="pl-4"
                   isActive={selectedAccountId === account.id}
+                  size="lg"
                   onClick={() => onAccountClick(account.id)}
                 >
-                  <span>{account.name}</span>
+                  <div className="flex flex-col">
+                    <span>{account.name}</span>
+                    <span className="text-xs text-muted-foreground">{account.bank}</span>
+                  </div>
                   <span className={cn(cnCurrencyColor(account.balance), 'ms-auto font-semibold')}>
                     {formatCurrency(account.balance)}
                   </span>

--- a/src/types/accounts/accountsErrors.ts
+++ b/src/types/accounts/accountsErrors.ts
@@ -1,6 +1,8 @@
 export const AccountsErrors = {
   NameRequired: 'errors.Account.Name.Required',
   NameTooLong: 'errors.Account.Name.TooLong',
+  BankRequired: 'errors.Account.Bank.Required',
+  BankTooLong: 'errors.Account.Bank.TooLong',
   AccountTypeUnknown: 'errors.Account.AccountType.Unknown',
   NotFound: 'errors.Account.NotFound',
   AlreadyDeleted: 'errors.Account.AlreadyDeleted',

--- a/src/types/accounts/forms/CreateAccountFormDto.ts
+++ b/src/types/accounts/forms/CreateAccountFormDto.ts
@@ -4,9 +4,11 @@ import { AccountsErrors } from '../accountsErrors'
 import { AccountTypeSchema } from '../enums/AccountType'
 
 const MAX_NAME_LENGTH = 20
+const MAX_BANK_LENGTH = 20
 
 export const CreateAccountFormSchema = z.object({
   name: z.string().min(1, { message: AccountsErrors.NameRequired }).max(MAX_NAME_LENGTH, { message: AccountsErrors.NameTooLong }),
+  bank: z.string().min(1, { message: AccountsErrors.BankRequired }).max(MAX_BANK_LENGTH, { message: AccountsErrors.BankTooLong }),
   type: AccountTypeSchema,
   initialBalance: z.number(),
 })

--- a/src/types/accounts/forms/RenameAccountFormDto.ts
+++ b/src/types/accounts/forms/RenameAccountFormDto.ts
@@ -3,9 +3,11 @@ import { z } from 'zod'
 import { AccountsErrors } from '../accountsErrors'
 
 const MAX_NAME_LENGTH = 20
+const MAX_BANK_LENGTH = 20
 
 export const RenameAccountFormSchema = z.object({
   name: z.string().min(1, { message: AccountsErrors.NameRequired }).max(MAX_NAME_LENGTH, { message: AccountsErrors.NameTooLong }),
+  bank: z.string().min(1, { message: AccountsErrors.BankRequired }).max(MAX_BANK_LENGTH, { message: AccountsErrors.BankTooLong }),
 })
 
 export type RenameAccountFormDto = z.infer<typeof RenameAccountFormSchema>

--- a/src/types/accounts/responses/CreateAccountResponseDto.ts
+++ b/src/types/accounts/responses/CreateAccountResponseDto.ts
@@ -3,6 +3,7 @@ import type { AccountType } from '../enums/AccountType'
 export type CreateAccountResponseDto = {
   id: string
   name: string
+  bank: string
   type: AccountType
   balance: number
   createdAt: string

--- a/src/types/accounts/responses/DeleteAccountResponseDto.ts
+++ b/src/types/accounts/responses/DeleteAccountResponseDto.ts
@@ -3,6 +3,7 @@ import type { AccountType } from '../enums/AccountType'
 export type DeleteAccountResponseDto = {
   id: string
   name: string
+  bank: string
   type: AccountType
   balance: number
   createdAt: string

--- a/src/types/accounts/responses/GetAccountsResponseDto.ts
+++ b/src/types/accounts/responses/GetAccountsResponseDto.ts
@@ -3,6 +3,7 @@ import type { AccountType } from '../enums/AccountType'
 export type GetAccountsResponseDto = {
   id: string
   name: string
+  bank: string
   type: AccountType
   balance: number
   createdAt: string

--- a/src/types/accounts/responses/RenameAccountResponseDto.ts
+++ b/src/types/accounts/responses/RenameAccountResponseDto.ts
@@ -3,6 +3,7 @@ import type { AccountType } from '../enums/AccountType'
 export type RenameAccountResponseDto = {
   id: string
   name: string
+  bank: string
   type: AccountType
   balance: number
   createdAt: string


### PR DESCRIPTION
**Form and Validation Updates:**

* Added a `bank` field to the account creation and rename forms, including validation for required and maximum length (20 characters). [[1]](diffhunk://#diff-9b692c711462d943009530b6099f286f46ae0a36924f1cae41d6bfdcccbf8ad6R53) [[2]](diffhunk://#diff-587b72b6161f0013270e776149baf7efc27ea9b93091410a8f5dea656bdd4a5aR7-R11) [[3]](diffhunk://#diff-5776abb87afa2b45f8e3e51c7b350f15e74aec35daedc5e2442d09dfcad7cf30R6-R10)
* Updated error messages and error keys to support bank-related validation errors. [[1]](diffhunk://#diff-1ef07a459de08da33c9f950f32e4e739683a016d219c16503bf8c3a5e2c973c7R4-R5) [[2]](diffhunk://#diff-71ed9b3b3eebf3e0d8ae84bb4e0c4cbbdb6e24651e3c654985911f89aa6678e8R4-R5)

**UI Improvements:**

* Display the bank name in the account list UI under each account name.
* Added the bank input to the account add form UI. [[1]](diffhunk://#diff-9b692c711462d943009530b6099f286f46ae0a36924f1cae41d6bfdcccbf8ad6R74) [[2]](diffhunk://#diff-1ef07a459de08da33c9f950f32e4e739683a016d219c16503bf8c3a5e2c973c7R32)

**API and Type Updates:**

* Extended account-related response DTOs to include the `bank` field, ensuring the bank name is available across account creation, deletion, renaming, and retrieval endpoints. [[1]](diffhunk://#diff-e0e42e7ac69750b1cbcff09322abed4c208b2993c2353c43738c5e527da7c683R6) [[2]](diffhunk://#diff-5d28c6cfb13ca8e0a4d1bb9fdff897d7400720c1fa2519abf52d4d3f816c7b82R6) [[3]](diffhunk://#diff-052a04a2abd33778b396710a3840be22bee1b0b5c77b114bdccf6191ab488141R6) [[4]](diffhunk://#diff-3531016ad31f9d03f715919eb4022f8fd0c8455237d27cde45c0d4937c97643fR6)