### PR TITLE
feat(accounts): implement account edit context menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.8",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -36,5 +36,7 @@
   "accounts.add.type.Savings": "Savings",
   "actions.cancel": "Cancel",
   "actions.save": "Save",
-  "common.noData": "No data"
+  "common.noData": "No data",
+  "common.edit": "Edit",
+  "common.delete": "Delete"
 }

--- a/src/app/main/MainLayout.tsx
+++ b/src/app/main/MainLayout.tsx
@@ -15,18 +15,33 @@ import {
   SidebarTrigger,
 } from '@/components/ui/Sidebar'
 import { AccountsSidebarContent } from '@/features/accounts/components/AccountsSidebarContent'
+import { useAccountsStore } from '@/features/accounts/stores/accountsStore'
 import { useSearchParams } from '@/hooks/useSearchParams'
+
+const SIDEBAR_SCALED_WIDTH = 80
+const HEADER_SCALED_HEIGHT = 12
 
 function MainLayout() {
   const { t } = useTranslation()
-  const [selectedAccountId, setSelectedAccountId] = useSearchParams<string | null>('accountId')
+
+  const { setSelectedAccountId } = useAccountsStore((state) => state.actions)
+  const selectedAccountId = useAccountsStore((state) => state.selectedAccountId)
+  const [queryParamAccountId, setQueryParamAccountId] = useSearchParams<string | null>('accountId')
+
+  React.useEffect(() => {
+    setSelectedAccountId(queryParamAccountId)
+  }, [queryParamAccountId, setSelectedAccountId])
+
+  React.useEffect(() => {
+    setQueryParamAccountId(selectedAccountId)
+  }, [selectedAccountId, setQueryParamAccountId])
 
   return (
     <SidebarProvider
       style={
         {
-          '--sidebar-width': 'calc(var(--spacing) * 72)',
-          '--header-height': 'calc(var(--spacing) * 12)',
+          '--sidebar-width': `calc(var(--spacing) * ${SIDEBAR_SCALED_WIDTH})`,
+          '--header-height': `calc(var(--spacing) * ${HEADER_SCALED_HEIGHT})`,
         } as React.CSSProperties
       }
     >
@@ -44,7 +59,7 @@ function MainLayout() {
           </SidebarMenu>
         </SidebarHeader>
 
-        <AccountsSidebarContent selectedAccountId={selectedAccountId} onAccountClick={setSelectedAccountId} />
+        <AccountsSidebarContent />
       </Sidebar>
 
       <SidebarInset>

--- a/src/components/ui/DropdownMenu.tsx
+++ b/src/components/ui/DropdownMenu.tsx
@@ -1,0 +1,210 @@
+import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu'
+import { CheckIcon, ChevronRightIcon, CircleIcon } from 'lucide-react'
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+function DropdownMenu({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+}
+
+function DropdownMenuPortal({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+  return <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+}
+
+function DropdownMenuTrigger({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return <DropdownMenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />
+}
+
+function DropdownMenuContent({
+  className,
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        className={cn(
+          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md',
+          className
+        )}
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  )
+}
+
+function DropdownMenuGroup({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+  return <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = 'default',
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+  inset?: boolean
+  variant?: 'default' | 'destructive'
+}) {
+  return (
+    <DropdownMenuPrimitive.Item
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      data-inset={inset}
+      data-slot="dropdown-menu-item"
+      data-variant={variant}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      checked={checked}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      data-slot="dropdown-menu-checkbox-item"
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  )
+}
+
+function DropdownMenuRadioGroup({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+  return <DropdownMenuPrimitive.RadioGroup data-slot="dropdown-menu-radio-group" {...props} />
+}
+
+function DropdownMenuRadioItem({ className, children, ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      data-slot="dropdown-menu-radio-item"
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CircleIcon className="size-2 fill-current" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.RadioItem>
+  )
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.Label
+      className={cn('px-2 py-1.5 text-sm font-medium data-[inset]:pl-8', className)}
+      data-inset={inset}
+      data-slot="dropdown-menu-label"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSeparator({ className, ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      className={cn('bg-border -mx-1 my-1 h-px', className)}
+      data-slot="dropdown-menu-separator"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuShortcut({ className, ...props }: React.ComponentProps<'span'>) {
+  return (
+    <span
+      className={cn('text-muted-foreground ml-auto text-xs tracking-widest', className)}
+      data-slot="dropdown-menu-shortcut"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSub({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.SubTrigger
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      data-inset={inset}
+      data-slot="dropdown-menu-sub-trigger"
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto size-4" />
+    </DropdownMenuPrimitive.SubTrigger>
+  )
+}
+
+function DropdownMenuSubContent({ className, ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  return (
+    <DropdownMenuPrimitive.SubContent
+      className={cn(
+        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg',
+        className
+      )}
+      data-slot="dropdown-menu-sub-content"
+      {...props}
+    />
+  )
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuPortal,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+}

--- a/src/features/accounts/components/AccountsList.tsx
+++ b/src/features/accounts/components/AccountsList.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { AccountsQueryOptions } from '@/api/endpoints/AccountsEndpoints'
@@ -13,12 +14,11 @@ import {
 import { cn, cnCurrencyColor, formatCurrency } from '@/lib/utils'
 import type { GetAccountsResponseDto } from '@/types/accounts/responses/GetAccountsResponseDto'
 
-type AccountsListProps = {
-  selectedAccountId: string | null
-  onAccountClick: (accountId: string | null) => void
-}
+import { useAccountsStore } from '../stores/accountsStore'
 
-function AccountsList({ selectedAccountId, onAccountClick }: AccountsListProps) {
+import { AccountsSettingsMenu } from './AccountsSettingsMenu'
+
+function AccountsList() {
   const { t } = useTranslation()
 
   const { data: accounts } = useQuery(AccountsQueryOptions.getAccounts())
@@ -28,20 +28,8 @@ function AccountsList({ selectedAccountId, onAccountClick }: AccountsListProps) 
 
   return (
     <>
-      <AccountGroup
-        accounts={checkingAccounts}
-        label={t('accounts.list.checking')}
-        labelNoData={t('common.noData')}
-        selectedAccountId={selectedAccountId}
-        onAccountClick={onAccountClick}
-      />
-      <AccountGroup
-        accounts={savingsAccounts}
-        label={t('accounts.list.savings')}
-        labelNoData={t('common.noData')}
-        selectedAccountId={selectedAccountId}
-        onAccountClick={onAccountClick}
-      />
+      <AccountGroup accounts={checkingAccounts} label={t('accounts.list.checking')} labelNoData={t('common.noData')} />
+      <AccountGroup accounts={savingsAccounts} label={t('accounts.list.savings')} labelNoData={t('common.noData')} />
     </>
   )
 }
@@ -50,11 +38,13 @@ type AccountGroupProps = {
   accounts: GetAccountsResponseDto[]
   label: string
   labelNoData: string
-  selectedAccountId: string | null
-  onAccountClick: (accountId: string | null) => void
 }
 
-function AccountGroup({ accounts, label, labelNoData, selectedAccountId, onAccountClick }: AccountGroupProps) {
+function AccountGroup({ accounts, label, labelNoData }: AccountGroupProps) {
+  const { setSelectedAccountId } = useAccountsStore((state) => state.actions)
+  const selectedAccountId = useAccountsStore((state) => state.selectedAccountId)
+  const [openMenuAccountId, setOpenMenuAccountId] = useState<string | null>(null)
+
   return (
     <SidebarGroup className="py-0">
       <SidebarGroupLabel>{label}</SidebarGroupLabel>
@@ -68,18 +58,31 @@ function AccountGroup({ accounts, label, labelNoData, selectedAccountId, onAccou
             accounts.map((account) => (
               <SidebarMenuItem key={account.id}>
                 <SidebarMenuButton
-                  className="pl-4"
+                  className="group/menu-button relative pl-4"
                   isActive={selectedAccountId === account.id}
                   size="lg"
-                  onClick={() => onAccountClick(account.id)}
+                  onClick={() => setSelectedAccountId(account.id)}
                 >
                   <div className="flex flex-col">
                     <span>{account.name}</span>
                     <span className="text-xs text-muted-foreground">{account.bank}</span>
                   </div>
-                  <span className={cn(cnCurrencyColor(account.balance), 'ms-auto font-semibold')}>
+                  <span
+                    className={cn(
+                      cnCurrencyColor(account.balance),
+                      'ms-auto pr-8 font-semibold transition-[padding,transform] md:pr-0 md:translate-x-0 md:group-hover/menu-button:-translate-x-4 md:group-focus-visible/menu-button:-translate-x-4 md:group-active/menu-button:-translate-x-4 md:group-hover/menu-button:pr-3 md:group-focus-visible/menu-button:pr-3 md:group-active/menu-button:pr-3',
+                      openMenuAccountId === account.id && 'md:-translate-x-4 md:pr-3'
+                    )}
+                  >
                     {formatCurrency(account.balance)}
                   </span>
+
+                  <AccountsSettingsMenu
+                    accountId={account.id}
+                    onOpenChange={(open) => {
+                      setOpenMenuAccountId((current) => (open ? account.id : current === account.id ? null : current))
+                    }}
+                  />
                 </SidebarMenuButton>
               </SidebarMenuItem>
             ))

--- a/src/features/accounts/components/AccountsNetWorth.tsx
+++ b/src/features/accounts/components/AccountsNetWorth.tsx
@@ -6,12 +6,11 @@ import { AccountsQueryOptions } from '@/api/endpoints/AccountsEndpoints'
 import { SidebarGroup, SidebarGroupContent, SidebarMenu, SidebarMenuButton } from '@/components/ui/Sidebar'
 import { cn, cnCurrencyColor, formatCurrency } from '@/lib/utils'
 
-type AccountsNetWorthProps = {
-  selectedAccountId: string | null
-  onAccountClick: (accountId: string | null) => void
-}
+import { useAccountsStore } from '../stores/accountsStore'
 
-function AccountsNetWorth({ selectedAccountId, onAccountClick }: AccountsNetWorthProps) {
+function AccountsNetWorth() {
+  const { setSelectedAccountId } = useAccountsStore((state) => state.actions)
+  const selectedAccountId = useAccountsStore((state) => state.selectedAccountId)
   const { t } = useTranslation()
 
   const { data: accounts } = useQuery(AccountsQueryOptions.getAccounts())
@@ -26,7 +25,7 @@ function AccountsNetWorth({ selectedAccountId, onAccountClick }: AccountsNetWort
             className="border"
             isActive={selectedAccountId === null}
             size="lg"
-            onClick={() => onAccountClick(null)}
+            onClick={() => setSelectedAccountId(null)}
           >
             <ChartPieIcon />
             <span>{t('accounts.netWorth')}</span>

--- a/src/features/accounts/components/AccountsSettingsMenu.tsx
+++ b/src/features/accounts/components/AccountsSettingsMenu.tsx
@@ -1,0 +1,72 @@
+import { PencilIcon, Settings2Icon, TrashIcon } from 'lucide-react'
+import { useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/DropdownMenu'
+
+import { useAccountsStore } from '../stores/accountsStore'
+
+type AccountsSettingsMenuProps = {
+  accountId: string
+  onOpenChange: (open: boolean) => void
+}
+
+function AccountsSettingsMenu({ accountId, onOpenChange }: AccountsSettingsMenuProps) {
+  const { t } = useTranslation()
+  const { setEditingAccountId, setDeletingAccountId } = useAccountsStore((state) => state.actions)
+
+  const handleEditClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      e.stopPropagation()
+      setEditingAccountId(accountId)
+      console.warn('Edition mode will be implemented in next pull request.', accountId)
+    },
+    [accountId, setEditingAccountId]
+  )
+
+  const handleDeleteClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      e.stopPropagation()
+      setDeletingAccountId(accountId)
+      console.warn('Deletion mode will be implemented in next pull request.', accountId)
+    },
+    [accountId, setDeletingAccountId]
+  )
+
+  return (
+    <DropdownMenu onOpenChange={onOpenChange}>
+      <DropdownMenuTrigger asChild>
+        <span
+          className="absolute right-3 flex size-6 translate-x-0 items-center justify-center rounded-md opacity-100 transition-all hover:bg-sidebar-border md:translate-x-2 md:opacity-0 md:group-hover/menu-button:translate-x-1 md:group-hover/menu-button:opacity-100 md:group-focus-visible/menu-button:translate-x-1 md:group-focus-visible/menu-button:opacity-100 md:group-active/menu-button:translate-x-1 md:group-active/menu-button:opacity-100 md:data-[state=open]:translate-x-1 md:data-[state=open]:opacity-100"
+          role="button"
+        >
+          <Settings2Icon className="size-4 text-muted-foreground" />
+        </span>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <DropdownMenuGroup>
+          <DropdownMenuItem onClick={handleEditClick}>
+            <PencilIcon />
+            {t('common.edit')}
+          </DropdownMenuItem>
+        </DropdownMenuGroup>
+        <DropdownMenuSeparator />
+        <DropdownMenuGroup>
+          <DropdownMenuItem variant="destructive" onClick={handleDeleteClick}>
+            <TrashIcon />
+            {t('common.delete')}
+          </DropdownMenuItem>
+        </DropdownMenuGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+export { AccountsSettingsMenu }

--- a/src/features/accounts/components/AccountsSidebarContent.tsx
+++ b/src/features/accounts/components/AccountsSidebarContent.tsx
@@ -5,16 +5,11 @@ import { AccountsAddFormDialog } from './AccountsAddFormDialog'
 import { AccountsList } from './AccountsList'
 import { AccountsNetWorth } from './AccountsNetWorth'
 
-type AccountsSidebarContentProps = {
-  selectedAccountId: string | null
-  onAccountClick: (accountId: string | null) => void
-}
-
-function AccountsSidebarContent({ selectedAccountId, onAccountClick }: AccountsSidebarContentProps) {
+function AccountsSidebarContent() {
   return (
     <SidebarContent>
-      <AccountsNetWorth selectedAccountId={selectedAccountId} onAccountClick={onAccountClick} />
-      <AccountsList selectedAccountId={selectedAccountId} onAccountClick={onAccountClick} />
+      <AccountsNetWorth />
+      <AccountsList />
 
       <AccountsAddButton />
       <AccountsAddFormDialog />

--- a/src/features/accounts/stores/accountsStore.ts
+++ b/src/features/accounts/stores/accountsStore.ts
@@ -1,21 +1,39 @@
 import { create } from 'zustand'
 
 type AccountsStore = {
+  selectedAccountId: string | null
   isCreatingAccount: boolean
+  editingAccountId: string | null
+  deletingAccountId: string | null
   actions: {
+    setSelectedAccountId: (value: string | null) => void
     setIsCreatingAccount: (value: boolean) => void
     toggleIsCreatingAccount: () => void
+    setEditingAccountId: (value: string | null) => void
+    setDeletingAccountId: (value: string | null) => void
   }
 }
 
 export const useAccountsStore = create<AccountsStore>((set, get) => ({
+  selectedAccountId: null,
   isCreatingAccount: false,
+  editingAccountId: null,
+  deletingAccountId: null,
   actions: {
+    setSelectedAccountId: (value: string | null) => {
+      set({ selectedAccountId: value })
+    },
     setIsCreatingAccount: (value: boolean) => {
       set({ isCreatingAccount: value })
     },
     toggleIsCreatingAccount: () => {
       set({ isCreatingAccount: !get().isCreatingAccount })
+    },
+    setEditingAccountId: (value: string | null) => {
+      set({ editingAccountId: value })
+    },
+    setDeletingAccountId: (value: string | null) => {
+      set({ deletingAccountId: value })
     },
   },
 }))

--- a/yarn.lock
+++ b/yarn.lock
@@ -991,6 +991,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-dropdown-menu@npm:^2.1.16":
+  version: 2.1.16
+  resolution: "@radix-ui/react-dropdown-menu@npm:2.1.16"
+  dependencies:
+    "@radix-ui/primitive": "npm:1.1.3"
+    "@radix-ui/react-compose-refs": "npm:1.1.2"
+    "@radix-ui/react-context": "npm:1.1.2"
+    "@radix-ui/react-id": "npm:1.1.1"
+    "@radix-ui/react-menu": "npm:2.1.16"
+    "@radix-ui/react-primitive": "npm:2.1.3"
+    "@radix-ui/react-use-controllable-state": "npm:1.2.2"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10/da215196b5dde5619cdb424b1b5236159e4bb949974b7f4ffbf047d467c55116229a8f9cf07eae6457afefb4a2b07888bb30542f303045e05d90a4b072941ae2
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-focus-guards@npm:1.1.3":
   version: 1.1.3
   resolution: "@radix-ui/react-focus-guards@npm:1.1.3"
@@ -1056,6 +1081,42 @@ __metadata:
     "@types/react-dom":
       optional: true
   checksum: 10/3c01d1ac184adff050931f0092a1b10e6f4cb15749dbd98ee8fb954af6b241c7cf5d39ea40775c27113d120ba672fd611951e3afaa9b09eb608ef3989a1ab1b2
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-menu@npm:2.1.16":
+  version: 2.1.16
+  resolution: "@radix-ui/react-menu@npm:2.1.16"
+  dependencies:
+    "@radix-ui/primitive": "npm:1.1.3"
+    "@radix-ui/react-collection": "npm:1.1.7"
+    "@radix-ui/react-compose-refs": "npm:1.1.2"
+    "@radix-ui/react-context": "npm:1.1.2"
+    "@radix-ui/react-direction": "npm:1.1.1"
+    "@radix-ui/react-dismissable-layer": "npm:1.1.11"
+    "@radix-ui/react-focus-guards": "npm:1.1.3"
+    "@radix-ui/react-focus-scope": "npm:1.1.7"
+    "@radix-ui/react-id": "npm:1.1.1"
+    "@radix-ui/react-popper": "npm:1.2.8"
+    "@radix-ui/react-portal": "npm:1.1.9"
+    "@radix-ui/react-presence": "npm:1.1.5"
+    "@radix-ui/react-primitive": "npm:2.1.3"
+    "@radix-ui/react-roving-focus": "npm:1.1.11"
+    "@radix-ui/react-slot": "npm:1.2.3"
+    "@radix-ui/react-use-callback-ref": "npm:1.1.1"
+    aria-hidden: "npm:^1.2.4"
+    react-remove-scroll: "npm:^2.6.3"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10/2ffdfa08822c8c4ffc265d02d16c83d725114f9c0e9b510e73e431306dedddd507ef2861ccd67ec8c0d21cb24cd6401e42f16f3e65b30be627c7e22159151e40
   languageName: node
   linkType: hard
 
@@ -1162,6 +1223,33 @@ __metadata:
     "@types/react-dom":
       optional: true
   checksum: 10/a718537c2e66d541e72cc6b92bcf8ba6a7a0b4a30072efadeac0a517eb36f8acc55f2983cc1e345dc0eae18166ebcace4dab0299ed87a79e8ac3f653df9ee437
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-roving-focus@npm:1.1.11":
+  version: 1.1.11
+  resolution: "@radix-ui/react-roving-focus@npm:1.1.11"
+  dependencies:
+    "@radix-ui/primitive": "npm:1.1.3"
+    "@radix-ui/react-collection": "npm:1.1.7"
+    "@radix-ui/react-compose-refs": "npm:1.1.2"
+    "@radix-ui/react-context": "npm:1.1.2"
+    "@radix-ui/react-direction": "npm:1.1.1"
+    "@radix-ui/react-id": "npm:1.1.1"
+    "@radix-ui/react-primitive": "npm:2.1.3"
+    "@radix-ui/react-use-callback-ref": "npm:1.1.1"
+    "@radix-ui/react-use-controllable-state": "npm:1.2.2"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10/0eddafa942332c95622ab8b53cce2fa25fd0dcaf4797218e9e6725da0734a81a438852cdcb3f588521018f68d38c6c5e50c64fda78c655f4e69dd45681ecc5e7
   languageName: node
   linkType: hard
 
@@ -5223,6 +5311,7 @@ __metadata:
     "@eslint/js": "npm:^9.39.2"
     "@hookform/resolvers": "npm:^5.2.2"
     "@radix-ui/react-dialog": "npm:^1.1.15"
+    "@radix-ui/react-dropdown-menu": "npm:^2.1.16"
     "@radix-ui/react-label": "npm:^2.1.8"
     "@radix-ui/react-select": "npm:^2.2.6"
     "@radix-ui/react-separator": "npm:^1.1.8"


### PR DESCRIPTION
**State Management Refactor:**

* Centralized account selection, editing, and deleting state in the `useAccountsStore` store, replacing previous prop drilling for `selectedAccountId` and related handlers. Components such as `MainLayout`, `AccountsSidebarContent`, `AccountsList`, and `AccountsNetWorth` now interact with the store directly. [[1]](diffhunk://#diff-6369df88e9c7c96272f380ef5586c9ae3959c313124eda503a020ae451814c74R18-R44) [[2]](diffhunk://#diff-6369df88e9c7c96272f380ef5586c9ae3959c313124eda503a020ae451814c74L47-R62) [[3]](diffhunk://#diff-6ad1808fdc8c5a0b16e8d76a46cf9e022fa0d64dc403e52971a4b3af0568c8d5L16-R21) [[4]](diffhunk://#diff-6ad1808fdc8c5a0b16e8d76a46cf9e022fa0d64dc403e52971a4b3af0568c8d5L53-R47) [[5]](diffhunk://#diff-9f10652ccbf8eabcb4e22f7aadf3cf24ca0f5da0e632328c8ed7806306440a3aL9-R13) [[6]](diffhunk://#diff-a03fa85850c3bac60b44c92ced03dfd3112dc3249e4c25059f1c8db6be88e556L8-R12) [[7]](diffhunk://#diff-ff0044e8e03ad9df7727097ec2d16e02c343d1e7df511bf266936d072de6c30aR4-R37)

**UI Enhancements:**

* Added the `AccountsSettingsMenu` component, which provides per-account edit and delete options via a dropdown menu, and integrated it into the account list UI. [[1]](diffhunk://#diff-6ad1808fdc8c5a0b16e8d76a46cf9e022fa0d64dc403e52971a4b3af0568c8d5L71-R85) [[2]](diffhunk://#diff-f7b792bedc14fd7e8ecaee4c7df74cffd5c00db8932ab1f0f3e7e373820f3e1aR1-R72)
* Introduced a new reusable `DropdownMenu` UI component based on `@radix-ui/react-dropdown-menu`, supporting various menu item types and styles.
* Updated sidebar layout constants for improved maintainability (`SIDEBAR_SCALED_WIDTH`, `HEADER_SCALED_HEIGHT`).

**Localization:**

* Added new translation keys for "Edit" and "Delete" actions to support the settings menu.

**Dependency Management:**

* Added `@radix-ui/react-dropdown-menu` to project dependencies for dropdown menu functionality.