### PR TITLE
feat(accounts): implement account delete

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
+    "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.8",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -34,9 +34,11 @@
   "accounts.add.type": "Type",
   "accounts.add.type.Checking": "Checking",
   "accounts.add.type.Savings": "Savings",
-  "actions.cancel": "Cancel",
+  "accounts.delete.title": "Delete Account",
+  "accounts.delete.description": "Are you sure you want to delete the account <b>{{accountName}}</b>?<br /><br />This action cannot be undone. To continue, type the account name below:",
   "actions.save": "Save",
-  "common.noData": "No data",
-  "common.edit": "Edit",
-  "common.delete": "Delete"
+  "actions.edit": "Edit",
+  "actions.delete": "Delete",
+  "actions.cancel": "Cancel",
+  "common.noData": "No data"
 }

--- a/src/api/endpoints/AccountsEndpoints.ts
+++ b/src/api/endpoints/AccountsEndpoints.ts
@@ -3,6 +3,7 @@ import { queryOptions } from '@tanstack/react-query'
 import { apiClient } from '@/lib/axios'
 import type { CreateAccountFormDto } from '@/types/accounts/forms/CreateAccountFormDto'
 import type { CreateAccountResponseDto } from '@/types/accounts/responses/CreateAccountResponseDto'
+import type { DeleteAccountResponseDto } from '@/types/accounts/responses/DeleteAccountResponseDto'
 import type { GetAccountsResponseDto } from '@/types/accounts/responses/GetAccountsResponseDto'
 
 import { queryKeys } from '../QueryKeys'
@@ -16,6 +17,10 @@ export const AccountsFn = {
   },
   createAccount: async (data: CreateAccountFormDto) => {
     const response = await apiClient.post<CreateAccountResponseDto>(`/${group}`, data)
+    return response.data
+  },
+  deleteAccount: async (id: string) => {
+    const response = await apiClient.delete<DeleteAccountResponseDto>(`/${group}/${id}`)
     return response.data
   },
 } as const

--- a/src/components/ui/AlertDialog.tsx
+++ b/src/components/ui/AlertDialog.tsx
@@ -1,0 +1,156 @@
+import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog'
+import * as React from 'react'
+
+import { Button } from '@/components/ui/Button'
+import { cn } from '@/lib/utils'
+
+function AlertDialog({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+}
+
+function AlertDialogPortal({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+}
+
+function AlertDialogOverlay({ className, ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      className={cn(
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+        className
+      )}
+      data-slot="alert-dialog-overlay"
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  size = 'default',
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content> & {
+  size?: 'default' | 'sm'
+}) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        className={cn(
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 group/alert-dialog-content fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-lg',
+          className
+        )}
+        data-size={size}
+        data-slot="alert-dialog-content"
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      className={cn(
+        'grid grid-rows-[auto_1fr] place-items-center gap-1.5 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-6 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]',
+        className
+      )}
+      data-slot="alert-dialog-header"
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      className={cn(
+        'flex flex-col-reverse gap-2 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end',
+        className
+      )}
+      data-slot="alert-dialog-footer"
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({ className, ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      className={cn(
+        'text-lg font-semibold sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2',
+        className
+      )}
+      data-slot="alert-dialog-title"
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({ className, ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      className={cn('text-muted-foreground text-sm', className)}
+      data-slot="alert-dialog-description"
+      {...props}
+    />
+  )
+}
+
+function AlertDialogMedia({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      className={cn(
+        "bg-muted mb-2 inline-flex size-16 items-center justify-center rounded-md sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-8",
+        className
+      )}
+      data-slot="alert-dialog-media"
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  variant = 'default',
+  size = 'default',
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action> & Pick<React.ComponentProps<typeof Button>, 'variant' | 'size'>) {
+  return (
+    <Button asChild size={size} variant={variant}>
+      <AlertDialogPrimitive.Action className={cn(className)} data-slot="alert-dialog-action" {...props} />
+    </Button>
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  variant = 'outline',
+  size = 'default',
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel> & Pick<React.ComponentProps<typeof Button>, 'variant' | 'size'>) {
+  return (
+    <Button asChild size={size} variant={variant}>
+      <AlertDialogPrimitive.Cancel className={cn(className)} data-slot="alert-dialog-cancel" {...props} />
+    </Button>
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+}

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -22,9 +22,11 @@ const buttonVariants = cva(
       },
       size: {
         default: 'h-9 px-4 py-2 has-[>svg]:px-3',
+        xs: "h-6 gap-1 rounded-md px-2 text-xs has-[>svg]:px-1.5 [&_svg:not([class*='size-'])]:size-3",
         sm: 'h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5',
         lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
         icon: 'size-9',
+        'icon-xs': "size-6 rounded-md [&_svg:not([class*='size-'])]:size-3",
         'icon-sm': 'size-8',
         'icon-lg': 'size-10',
       },

--- a/src/features/accounts/components/AccountsDeleteDialog.tsx
+++ b/src/features/accounts/components/AccountsDeleteDialog.tsx
@@ -1,0 +1,116 @@
+import { useMutation, useQuery } from '@tanstack/react-query'
+import { Trash2Icon } from 'lucide-react'
+import { useCallback, useRef, useState } from 'react'
+import { Trans, useTranslation } from 'react-i18next'
+
+import { AccountsFn, AccountsQueryOptions } from '@/api/endpoints/AccountsEndpoints'
+import { queryKeys } from '@/api/QueryKeys'
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogTitle,
+} from '@/components/ui/AlertDialog'
+import { Button } from '@/components/ui/Button'
+import { Input } from '@/components/ui/Input'
+
+import { useAccountsStore } from '../stores/accountsStore'
+
+function AccountsDeleteDialog() {
+  const { t } = useTranslation()
+  const [confirmation, setConfirmation] = useState<string>('')
+  const confirmationInputRef = useRef<HTMLInputElement>(null)
+
+  const deletingAccountId = useAccountsStore((state) => state.deletingAccountId)
+  const { setDeletingAccountId } = useAccountsStore((state) => state.actions)
+
+  const { data: accounts } = useQuery(AccountsQueryOptions.getAccounts())
+  const account = accounts?.find((account) => account.id === deletingAccountId)
+  const accountName = account?.name ?? ''
+  const canDelete = confirmation === accountName
+
+  const { mutate: deleteAccount, isPending } = useMutation({
+    mutationFn: AccountsFn.deleteAccount,
+    onSuccess: (_, __, ___, context) => {
+      setDeletingAccountId(null)
+      setConfirmation('')
+      context.client.invalidateQueries({ queryKey: queryKeys.accounts.all })
+    },
+  })
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        setDeletingAccountId(null)
+        setConfirmation('')
+      }
+    },
+    [setDeletingAccountId]
+  )
+
+  const handleDelete = useCallback(() => {
+    if (deletingAccountId) {
+      deleteAccount(deletingAccountId)
+    }
+  }, [deleteAccount, deletingAccountId])
+
+  return (
+    <AlertDialog open={!!deletingAccountId} onOpenChange={handleOpenChange}>
+      <AlertDialogContent
+        size="default"
+        onOpenAutoFocus={(event) => {
+          event.preventDefault()
+          requestAnimationFrame(() => confirmationInputRef.current?.focus())
+        }}
+      >
+        <AlertDialogHeader>
+          <AlertDialogMedia className="bg-destructive/10 text-destructive dark:bg-destructive/20 dark:text-destructive">
+            <Trash2Icon />
+          </AlertDialogMedia>
+          <AlertDialogTitle>{t('accounts.delete.title')}</AlertDialogTitle>
+          <AlertDialogDescription>
+            <Trans i18nKey="accounts.delete.description" values={{ accountName }} />
+            <Input
+              ref={confirmationInputRef}
+              autoFocus
+              className="mt-4"
+              value={confirmation}
+              onBlur={() => {
+                if (!canDelete) {
+                  confirmationInputRef.current?.focus()
+                }
+              }}
+              onChange={(e) => setConfirmation(e.target.value)}
+              onFocus={() => {
+                if (!canDelete) {
+                  confirmationInputRef.current?.select()
+                }
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  if (canDelete) {
+                    handleDelete()
+                  }
+                }
+              }}
+            />
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isPending} variant="outline">
+            {t('actions.cancel')}
+          </AlertDialogCancel>
+          <Button disabled={!canDelete} loading={isPending} variant="destructive" onClick={handleDelete}>
+            {t('actions.delete')}
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}
+
+export { AccountsDeleteDialog }

--- a/src/features/accounts/components/AccountsSettingsMenu.tsx
+++ b/src/features/accounts/components/AccountsSettingsMenu.tsx
@@ -35,7 +35,6 @@ function AccountsSettingsMenu({ accountId, onOpenChange }: AccountsSettingsMenuP
     (e: React.MouseEvent<HTMLDivElement>) => {
       e.stopPropagation()
       setDeletingAccountId(accountId)
-      console.warn('Deletion mode will be implemented in next pull request.', accountId)
     },
     [accountId, setDeletingAccountId]
   )
@@ -54,14 +53,14 @@ function AccountsSettingsMenu({ accountId, onOpenChange }: AccountsSettingsMenuP
         <DropdownMenuGroup>
           <DropdownMenuItem onClick={handleEditClick}>
             <PencilIcon />
-            {t('common.edit')}
+            {t('actions.edit')}
           </DropdownMenuItem>
         </DropdownMenuGroup>
         <DropdownMenuSeparator />
         <DropdownMenuGroup>
           <DropdownMenuItem variant="destructive" onClick={handleDeleteClick}>
             <TrashIcon />
-            {t('common.delete')}
+            {t('actions.delete')}
           </DropdownMenuItem>
         </DropdownMenuGroup>
       </DropdownMenuContent>

--- a/src/features/accounts/components/AccountsSidebarContent.tsx
+++ b/src/features/accounts/components/AccountsSidebarContent.tsx
@@ -2,6 +2,7 @@ import { SidebarContent } from '@/components/ui/Sidebar'
 
 import { AccountsAddButton } from './AccountsAddButton'
 import { AccountsAddFormDialog } from './AccountsAddFormDialog'
+import { AccountsDeleteDialog } from './AccountsDeleteDialog'
 import { AccountsList } from './AccountsList'
 import { AccountsNetWorth } from './AccountsNetWorth'
 
@@ -13,6 +14,7 @@ function AccountsSidebarContent() {
 
       <AccountsAddButton />
       <AccountsAddFormDialog />
+      <AccountsDeleteDialog />
     </SidebarContent>
   )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -856,6 +856,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-alert-dialog@npm:^1.1.15":
+  version: 1.1.15
+  resolution: "@radix-ui/react-alert-dialog@npm:1.1.15"
+  dependencies:
+    "@radix-ui/primitive": "npm:1.1.3"
+    "@radix-ui/react-compose-refs": "npm:1.1.2"
+    "@radix-ui/react-context": "npm:1.1.2"
+    "@radix-ui/react-dialog": "npm:1.1.15"
+    "@radix-ui/react-primitive": "npm:2.1.3"
+    "@radix-ui/react-slot": "npm:1.2.3"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10/587d906f720a7b16c55f35767a469c3e707e985cebf2f14a64dc4606d2609a337bb9d9c93d86755a7597ba2dc1d41b0f5c2da4c0058f494085e69de0023f0283
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-arrow@npm:1.1.7":
   version: 1.1.7
   resolution: "@radix-ui/react-arrow@npm:1.1.7"
@@ -923,7 +947,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-dialog@npm:^1.1.1, @radix-ui/react-dialog@npm:^1.1.15":
+"@radix-ui/react-dialog@npm:1.1.15, @radix-ui/react-dialog@npm:^1.1.1, @radix-ui/react-dialog@npm:^1.1.15":
   version: 1.1.15
   resolution: "@radix-ui/react-dialog@npm:1.1.15"
   dependencies:
@@ -5310,6 +5334,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:^9.39.2"
     "@hookform/resolvers": "npm:^5.2.2"
+    "@radix-ui/react-alert-dialog": "npm:^1.1.15"
     "@radix-ui/react-dialog": "npm:^1.1.15"
     "@radix-ui/react-dropdown-menu": "npm:^2.1.16"
     "@radix-ui/react-label": "npm:^2.1.8"


### PR DESCRIPTION
**Account Deletion Feature:**

* Added a new `AccountsDeleteDialog` component that displays a confirmation dialog requiring the user to type the account name before deletion; integrates with backend deletion and updates the UI accordingly (`src/features/accounts/components/AccountsDeleteDialog.tsx`, `src/features/accounts/components/AccountsSidebarContent.tsx`). [[1]](diffhunk://#diff-8b234180c7eed65e3b092e0e7d041aac2937bb0494934194bf27b8027113f18cR1-R116) [[2]](diffhunk://#diff-a03fa85850c3bac60b44c92ced03dfd3112dc3249e4c25059f1c8db6be88e556R5) [[3]](diffhunk://#diff-a03fa85850c3bac60b44c92ced03dfd3112dc3249e4c25059f1c8db6be88e556R17)
* Implemented the `deleteAccount` API function and mutation, enabling actual account deletion on the backend (`src/api/endpoints/AccountsEndpoints.ts`). [[1]](diffhunk://#diff-b91808e6800d7ff04b11ac8ccc231fb54849d32c0f97e98bec3f673444f0bb64R6) [[2]](diffhunk://#diff-b91808e6800d7ff04b11ac8ccc231fb54849d32c0f97e98bec3f673444f0bb64R22-R25)

**UI Components and Styling:**

* Added a reusable `AlertDialog` component, wrapping Radix UI's alert dialog primitives, to standardize confirmation dialogs throughout the app (`src/components/ui/AlertDialog.tsx`).
* Enhanced `Button` component variants with new sizes (`xs`, `icon-xs`) for better UI flexibility (`src/components/ui/Button.tsx`).

**Localization and Menu Consistency:**

* Updated English translations to support account deletion dialogs and standardized action labels (edit, delete, cancel) (`public/locales/en.json`).
* Refactored `AccountsSettingsMenu` to trigger the delete dialog and use consistent action labels (`src/features/accounts/components/AccountsSettingsMenu.tsx`). [[1]](diffhunk://#diff-f7b792bedc14fd7e8ecaee4c7df74cffd5c00db8932ab1f0f3e7e373820f3e1aL38) [[2]](diffhunk://#diff-f7b792bedc14fd7e8ecaee4c7df74cffd5c00db8932ab1f0f3e7e373820f3e1aL57-R63)