### PR TITLE
feat(main): create account breadcrumb

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -4,6 +4,7 @@
   "accounts.actions.delete.title": "Delete Account",
   "accounts.actions.patch.title": "Edit Account",
   "accounts.actions.patch.updateInitialBalance": "Update initial balance",
+  "accounts.allAccounts": "All accounts",
   "accounts.bank": "Bank",
   "accounts.initialBalance": "Initial Balance",
   "accounts.name": "Name",
@@ -50,5 +51,7 @@
   "errors.User.Login.TooLong": "Login too long",
   "errors.User.NotFound": "User not found",
   "errors.User.Password.Required": "Password required",
-  "errors.User.RefreshToken.Required": "Refresh token required"
+  "errors.User.RefreshToken.Required": "Refresh token required",
+
+  "operations.title": "Operations"
 }

--- a/src/api/endpoints/AccountsEndpoints.ts
+++ b/src/api/endpoints/AccountsEndpoints.ts
@@ -22,6 +22,11 @@ export function useGetAccounts() {
   })
 }
 
+export function useGetAccountById(id: string | null) {
+  const accountsQuery = useGetAccounts()
+  return accountsQuery.data?.find((account) => account.id === id)
+}
+
 export function useCreateAccount() {
   return useMutation({
     mutationFn: async (data: CreateAccountFormDto) => {

--- a/src/app/main/MainLayout.tsx
+++ b/src/app/main/MainLayout.tsx
@@ -14,6 +14,7 @@ import {
   SidebarProvider,
   SidebarTrigger,
 } from '@/components/ui/Sidebar'
+import { AccountsBreadcrumb } from '@/features/accounts/components/AccountsBreadcrumb'
 import { AccountsSidebarContent } from '@/features/accounts/components/AccountsSidebarContent'
 import { useAccountsStore } from '@/features/accounts/stores/accountsStore'
 import { useSearchParams } from '@/hooks/useSearchParams'
@@ -67,8 +68,7 @@ function MainLayout() {
           <div className="flex w-full items-center gap-1 px-4 lg:gap-2 lg:px-6">
             <SidebarTrigger className="-ml-1" />
             <Separator className="mx-2 data-[orientation=vertical]:h-4" orientation="vertical" />
-            {/* TODO: maybe use a breadcrumb here? or maybe i18n to transaltion the location pathname? */}
-            <h1 className="text-base font-medium">Operations</h1>
+            <AccountsBreadcrumb />
           </div>
         </header>
         <div className="flex flex-1 flex-col">

--- a/src/components/ui/Breadcrumb.tsx
+++ b/src/components/ui/Breadcrumb.tsx
@@ -1,0 +1,79 @@
+import { Slot } from '@radix-ui/react-slot'
+import { ChevronRight, MoreHorizontal } from 'lucide-react'
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+function Breadcrumb({ ...props }: React.ComponentProps<'nav'>) {
+  return <nav aria-label="breadcrumb" data-slot="breadcrumb" {...props} />
+}
+
+function BreadcrumbList({ className, ...props }: React.ComponentProps<'ol'>) {
+  return (
+    <ol
+      className={cn('text-muted-foreground flex flex-wrap items-center gap-1.5 text-sm break-words sm:gap-2.5', className)}
+      data-slot="breadcrumb-list"
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbItem({ className, ...props }: React.ComponentProps<'li'>) {
+  return <li className={cn('inline-flex items-center gap-1.5', className)} data-slot="breadcrumb-item" {...props} />
+}
+
+function BreadcrumbLink({
+  asChild,
+  className,
+  ...props
+}: React.ComponentProps<'a'> & {
+  asChild?: boolean
+}) {
+  const Comp = asChild ? Slot : 'a'
+
+  return <Comp className={cn('hover:text-foreground transition-colors', className)} data-slot="breadcrumb-link" {...props} />
+}
+
+function BreadcrumbPage({ className, ...props }: React.ComponentProps<'span'>) {
+  return (
+    <span
+      aria-current="page"
+      aria-disabled="true"
+      className={cn('text-foreground font-normal', className)}
+      data-slot="breadcrumb-page"
+      role="link"
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbSeparator({ children, className, ...props }: React.ComponentProps<'li'>) {
+  return (
+    <li
+      aria-hidden="true"
+      className={cn('[&>svg]:size-3.5', className)}
+      data-slot="breadcrumb-separator"
+      role="presentation"
+      {...props}
+    >
+      {children ?? <ChevronRight />}
+    </li>
+  )
+}
+
+function BreadcrumbEllipsis({ className, ...props }: React.ComponentProps<'span'>) {
+  return (
+    <span
+      aria-hidden="true"
+      className={cn('flex size-9 items-center justify-center', className)}
+      data-slot="breadcrumb-ellipsis"
+      role="presentation"
+      {...props}
+    >
+      <MoreHorizontal className="size-4" />
+      <span className="sr-only">More</span>
+    </span>
+  )
+}
+
+export { Breadcrumb, BreadcrumbEllipsis, BreadcrumbItem, BreadcrumbLink, BreadcrumbList, BreadcrumbPage, BreadcrumbSeparator }

--- a/src/features/accounts/components/AccountsBreadcrumb.tsx
+++ b/src/features/accounts/components/AccountsBreadcrumb.tsx
@@ -1,0 +1,41 @@
+import { useTranslation } from 'react-i18next'
+
+import { useGetAccountById } from '@/api/endpoints/AccountsEndpoints'
+import { Breadcrumb, BreadcrumbItem, BreadcrumbList, BreadcrumbPage, BreadcrumbSeparator } from '@/components/ui/Breadcrumb'
+
+import { useAccountsStore } from '../stores/accountsStore'
+
+function AccountsBreadcrumb() {
+  const { t } = useTranslation()
+
+  const selectedAccountId = useAccountsStore((state) => state.selectedAccountId)
+  const account = useGetAccountById(selectedAccountId)
+
+  return (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbPage>{t('operations.title')}</BreadcrumbPage>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        {account ? (
+          <>
+            <BreadcrumbItem>
+              <BreadcrumbPage>{account.bank}</BreadcrumbPage>
+            </BreadcrumbItem>
+            <BreadcrumbSeparator />
+            <BreadcrumbItem>
+              <BreadcrumbPage>{account.name}</BreadcrumbPage>
+            </BreadcrumbItem>
+          </>
+        ) : (
+          <BreadcrumbItem>
+            <BreadcrumbPage>{t('accounts.allAccounts')}</BreadcrumbPage>
+          </BreadcrumbItem>
+        )}
+      </BreadcrumbList>
+    </Breadcrumb>
+  )
+}
+
+export { AccountsBreadcrumb }

--- a/src/features/accounts/components/forms/AccountsDeleteFormDialog.tsx
+++ b/src/features/accounts/components/forms/AccountsDeleteFormDialog.tsx
@@ -2,7 +2,7 @@ import { Trash2Icon } from 'lucide-react'
 import React from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 
-import { useDeleteAccount, useGetAccounts } from '@/api/endpoints/AccountsEndpoints'
+import { useDeleteAccount, useGetAccountById } from '@/api/endpoints/AccountsEndpoints'
 import {
   AlertDialog,
   AlertDialogCancel,
@@ -26,8 +26,7 @@ function AccountsDeleteFormDialog() {
   const deletingAccountId = useAccountsStore((state) => state.deletingAccountId)
   const { setDeletingAccountId } = useAccountsStore((state) => state.actions)
 
-  const accountsQuery = useGetAccounts()
-  const account = accountsQuery.data?.find((account) => account.id === deletingAccountId)
+  const account = useGetAccountById(deletingAccountId)
   const accountName = account?.name ?? ''
   const canDelete = confirmation === accountName
 

--- a/src/features/accounts/components/forms/AccountsPatchFormDialog.tsx
+++ b/src/features/accounts/components/forms/AccountsPatchFormDialog.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { useForm, useWatch } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 
-import { useGetAccounts, usePatchAccount } from '@/api/endpoints/AccountsEndpoints'
+import { useGetAccountById, usePatchAccount } from '@/api/endpoints/AccountsEndpoints'
 import { CheckboxControlled } from '@/components/forms/CheckboxControlled'
 import { InputControlled } from '@/components/forms/InputControlled'
 import { InputNumberControlled } from '@/components/forms/InputNumberControlled'
@@ -41,9 +41,7 @@ function AccountPatchForm({ accountId }: { accountId: string }) {
   const { t } = useTranslation()
   const setPatchingAccountId = useAccountsStore((state) => state.actions.setPatchingAccountId)
 
-  const getAccountQuery = useGetAccounts()
-  const account = getAccountQuery.data?.find((account) => account.id === accountId)
-
+  const account = useGetAccountById(accountId)
   const patchAccountMutation = usePatchAccount()
 
   const form = useForm<PatchAccountSchemaDto>({


### PR DESCRIPTION
**Breadcrumb Navigation Implementation:**

* Added a new `AccountsBreadcrumb` component that displays a breadcrumb trail based on the selected account, showing "Operations", the bank name, and the account name, or "All accounts" if no account is selected. (`src/features/accounts/components/AccountsBreadcrumb.tsx`)
* Replaced the static operations title in the main layout with the new `AccountsBreadcrumb` component, making the header more informative and dynamic. (`src/app/main/MainLayout.tsx`) [[1]](diffhunk://#diff-6369df88e9c7c96272f380ef5586c9ae3959c313124eda503a020ae451814c74R17) [[2]](diffhunk://#diff-6369df88e9c7c96272f380ef5586c9ae3959c313124eda503a020ae451814c74L70-R71)

**UI Component Additions:**

* Introduced a reusable `Breadcrumb` UI component and related subcomponents (`BreadcrumbList`, `BreadcrumbItem`, `BreadcrumbLink`, `BreadcrumbPage`, `BreadcrumbSeparator`, `BreadcrumbEllipsis`) to support breadcrumb navigation throughout the app. (`src/components/ui/Breadcrumb.tsx`)

**Localization Enhancements:**

* Added new translation strings for "All accounts" and "Operations" to the English locale file to support the breadcrumb and improve internationalization. (`public/locales/en.json`) [[1]](diffhunk://#diff-1ef07a459de08da33c9f950f32e4e739683a016d219c16503bf8c3a5e2c973c7R7) [[2]](diffhunk://#diff-1ef07a459de08da33c9f950f32e4e739683a016d219c16503bf8c3a5e2c973c7L53-R56)